### PR TITLE
HOME-43 - UI requests towards agent API fails occasionally

### DIFF
--- a/client/modules/Dashboard/sagas.js
+++ b/client/modules/Dashboard/sagas.js
@@ -52,8 +52,14 @@ function* fetchAlerts() {
 
 function getData(agentId) {
   return fetch(`/api/home/${agentId}`)
-    .then(response => response.json())
-    .catch(() => "Fetching data failed");
+    .then(response => {
+      if (!response.ok) {
+        throw response.statusText;
+      }
+
+      return response.json();
+    })
+    .catch((e) => e);
 }
 
 function* fetchData() {
@@ -76,7 +82,7 @@ function* fetchData() {
       yield put(actions.fetchDataFail(data));
     }
 
-    yield delay(3000);
+    yield delay(5000);
   }
 }
 

--- a/client/modules/Dashboard/sagas.js
+++ b/client/modules/Dashboard/sagas.js
@@ -54,7 +54,11 @@ function getData(agentId) {
   return fetch(`/api/home/${agentId}`)
     .then(response => {
       if (!response.ok) {
-        throw response.statusText;
+        throw `Fetching data error: ${response.statusText}`;
+      }
+
+      if (response.status == 204) {
+        throw 'No data available';
       }
 
       return response.json();

--- a/controllers/api/home.go
+++ b/controllers/api/home.go
@@ -31,20 +31,26 @@ func CtrHome(w http.ResponseWriter, r *http.Request, opt router.UrlOptions, sm s
     agentName := opt.Params["agent"]
 
     if services.InfluxConnected != true {
+        w.WriteHeader(http.StatusInternalServerError)
         log.Println("services: cannot feed data , Influx seems to be down")
         return
     }
 
     q := client.Query{
-        Command:    "SELECT time, temperature, presence, gas, sound, agent FROM '" + agentName + "' ORDER BY time DESC LIMIT 30",
+        Command:    "SELECT time, temperature, presence, gas, sound, agent FROM " + agentName + " ORDER BY time DESC LIMIT 30",
         Database:   "smarthome",
     }
 
     resp, err := services.InfluxClient.Query(q)
 
-    if err != nil || len(resp.Results) == 0 {
+    if err != nil {
         w.WriteHeader(http.StatusInternalServerError)
         log.Println("services: ", err)
+        return
+    }
+
+    if len(resp.Results) == 0 {
+        w.WriteHeader(http.StatusNoContent)
         return
     }
 

--- a/controllers/api/home.go
+++ b/controllers/api/home.go
@@ -36,14 +36,16 @@ func CtrHome(w http.ResponseWriter, r *http.Request, opt router.UrlOptions, sm s
     }
 
     q := client.Query{
-        Command:    "SELECT time, temperature, presence, gas, sound, agent FROM home WHERE agent = '" + agentName + "' ORDER BY time DESC LIMIT 30",
+        Command:    "SELECT time, temperature, presence, gas, sound, agent FROM '" + agentName + "' ORDER BY time DESC LIMIT 30",
         Database:   "smarthome",
     }
 
     resp, err := services.InfluxClient.Query(q)
 
-    if err != nil {
+    if err != nil || len(resp.Results) == 0 {
+        w.WriteHeader(http.StatusInternalServerError)
         log.Println("services: ", err)
+        return
     }
 
     res := resp.Results[0].Series[0]

--- a/services/home.go
+++ b/services/home.go
@@ -125,8 +125,8 @@ func (a Agent) fetchPackage() {
     }
 
     pt, _ := client.NewPoint(
-        "home",
-        map[string]string{ "home": "home" },
+        a.Name,
+        map[string]string{ "home": a.Name },
         map[string]interface{}{
             "temperature": temperature,
             "presence": motion,


### PR DESCRIPTION
**Business justification:** https://trello.com/c/9Gzk5im6/43-home-39-ui-requests-towards-agent-api-fails-occassionaly

**Description:**
Occasionaly http requests towards agent end-points failed. The underlying reason standing behind that was the fact that making queries to influx db with `WHERE agent=` was causing a huge delay.

The fix is to split agents among separate measurements.